### PR TITLE
Remove (hidden) video on home page and use HTTPS for google fonts

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -40,7 +40,7 @@
 	</script>
 
 	<noscript>
-		<link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7CVolkhov' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic%7CVolkhov' rel='stylesheet' type='text/css'>
 	</noscript>
 
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -16,8 +16,6 @@ widget2:
   title: "Who?"
   image: friends-302x182.png
   text: 'We are an inclusive team of volunteers with the expertise and passion in perfusion analysis, open source software and reproducible science. Join our growing group to help us make a difference!'
-
-  #video: '<a href="#" data-reveal-id="videoModal"><img src="http://phlow.github.io/feeling-responsive/images/start-video-feeling-responsive-302x182.jpg" width="302" height="182" alt=""/></a>'
 widget3:
   title: "What?"
   image: curve_segment_larger-302x182.png  
@@ -48,9 +46,3 @@ permalink: /index.html
 homepage: true
 ---
 
-<div id="videoModal" class="reveal-modal large" data-reveal="">
-  <div class="flex-video widescreen vimeo" style="display: block;">
-    <iframe width="1280" height="720" src="https://www.youtube.com/embed/3b5zCFSmVvU" frameborder="0" allowfullscreen></iframe>
-  </div>
-  <a class="close-reveal-modal">&#215;</a>
-</div>


### PR DESCRIPTION
This PR removes an unrelated video on the main page---looks like it's a holdover from the Jekyll theme?
The video is usually hidden, but it shows up if https is enforced in the url, i.e. https://www.osipi.org/

The google fonts api was also changed to use https, as a first step to resolving #4 
