### PR TITLE
Fix liquid syntax error along with typo in name

### DIFF
--- a/_posts/2019-05-17-ISMRM2019-OSIPI-F2F.md
+++ b/_posts/2019-05-17-ISMRM2019-OSIPI-F2F.md
@@ -18,7 +18,7 @@ categories:
 
 **Attendees**
 
-Thanks for joining us! _Zaki Ahmrf, Udunna Anazodo, Daniel Barboriak, Laura Bell, Benoit Bourassa-Moreau, Irene Brumer, Paula Croal, Greg Cron, Charlotte Debus, Tanguy Duval, Klaus Eickel, Andrey Fedorov,Xavier Golay, Ingomar Gutmann,Ina Nora Kompan, Ives Levesque, Simon Levy, Thomas Lindner, Hanzhang Lu, Henk Mutsaerts, Aaron Oliver-Taylor, Jan Petr, Steven Sourbron, Yuriko Suzuki, David Thomas, Marta Tibiletti, Tanja Uhrig, and Frank Zollner_  
+Thanks for joining us! _Zaki Ahmed, Udunna Anazodo, Daniel Barboriak, Laura Bell, Benoit Bourassa-Moreau, Irene Brumer, Paula Croal, Greg Cron, Charlotte Debus, Tanguy Duval, Klaus Eickel, Andrey Fedorov,Xavier Golay, Ingomar Gutmann,Ina Nora Kompan, Ives Levesque, Simon Levy, Thomas Lindner, Hanzhang Lu, Henk Mutsaerts, Aaron Oliver-Taylor, Jan Petr, Steven Sourbron, Yuriko Suzuki, David Thomas, Marta Tibiletti, Tanja Uhrig, and Frank Zollner_  
 
 **Agenda**
 

--- a/pages/pages-root-folder/events.html
+++ b/pages/pages-root-folder/events.html
@@ -23,7 +23,7 @@ permalink: "/events/"
 			<a href="#panel{{ counter }}"><span class="iconfont"></span> {% if post.subheadline %}{{ post.subheadline }} › {% endif %}<strong>{{ post.title }}</strong></a>
 				<div id="panel{{ counter }}" class="content">
 					  {% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %}
-					  <a href="{{ site.url }}{{ post.url }}" title="Read {{ post.title escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br>
+					  <a href="{{ site.url }}{{ post.url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br>
 				</div>
 			</dd>
 			{% assign counter=counter | plus:1 %}


### PR DESCRIPTION
- While building the site locally, I kept getting the following error/warning:
```
Liquid Warning: Liquid syntax error (line 15): Expected end_of_string but found id in "{{ post.title escape_once }}" in pages/pages-root-folder/events.html
```
Seemed harmless but fixed anyways by inserting a `|` in the offending code.

- Fixed a typo in my name. I misspelt it when I registered for the F2F meeting 🤦‍♂ 