### PR TITLE
Remove buttons for News/Events Archive

### DIFF
--- a/_includes/_meta_information.html
+++ b/_includes/_meta_information.html
@@ -22,7 +22,9 @@
 				{% if page.previous.url %}
 				<div class="small-5 columns"><a class="button small radius prev" href="{{ site.url }}{{ site.baseurl }}{{page.previous.url}}">&laquo; {{page.previous.title}}</a></div><!-- /.small-4.columns -->
 				{% endif %}
-				<div class="small-2 columns text-center"><a class="radius button small" href="{{ site.url }}{{ site.baseurl }}/news/archive/" title="Blog {{ site.data.language.archive }}">{{ site.data.language.archive }}</a></div><!-- /.small-4.columns -->
+				<!-- Uncomment to reinstate Archive link
+				<div class="small-2 columns text-center"><a class="radius button small" href="{{ site.url }}{{ site.baseurl }}/news/archive/" title="Blog {{ site.data.language.archive }}">{{ site.data.language.archive }}</a></div>
+				-->
 				{% if page.next.url %}
 				<div class="small-5 columns text-right"><a class="button small radius next" href="{{ site.url }}{{ site.baseurl }}{{page.next.url}}">{{page.next.title}} &raquo;</a></div><!-- /.small-4.columns -->
 				{% else %}

--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -40,7 +40,9 @@
       {% endif %}
     {% endif %}
 
+    <!-- Uncomment to reinstate Archive link
     <a class="radius button small" href="{{ site.url }}{{ site.baseurl }}/news/archive/" title="{{ site.data.language.archive }}">{{ site.data.language.archive }}</a>
+    -->
 
     {% if paginator.next_page %}
     <a rel="next" class="radius button small" href="{{ site.url }}{{ site.baseurl }}/news/page{{ paginator.next_page }}/" title="{{ site.data.language.next_posts }}">{{ site.data.language.next }} &raquo;</a>


### PR DESCRIPTION
Following up on #38, this PR removes the Archive button from the bottom of the News pages. [[Preview](https://notzaki.github.io/osipi.github.io/news/)]
