### PR TITLE
Visual changes to Taskforce 6 & auto-populate EMB members list

### DIFF
--- a/_data/tf/tf_6_1.yml
+++ b/_data/tf/tf_6_1.yml
@@ -1,0 +1,34 @@
+title: "OSIPI Task Force 6.1: Challenges"
+aims: Develop and implement challenges involving perfusion imaging analysis
+description: |
+  Development of benchmarks and application to existing software. 
+  Using the data collected in aim #3, develop metrics that quantify the performance of a perfusion analysis tool (eg. bias and precision on DRO’s, agreement with reference methods in-vivo, reproducibility on in-vivo data, processing time, etc). 
+  These metrics will be measured for the software tools collected in aims #1 and #2 in order to establish a set of benchmarks. 
+  The long-term aim is to establish OSIPI as an independent arbiter for software solutions in perfusion imaging. 
+  TF 6.1 will focus on the developing and implementing challenges.
+subgroups:
+  - name: DSC challenge members
+    leads:
+      - name: Anahita Fathi
+        location: University of Pennsylvania
+        photo: anonymous_headshot.png 
+        website: https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/
+        role: Lead
+    members:
+      - TBC
+  - name: ASL challenge members
+    leads:
+      - name: Paola Croal
+        location: University of Oxford
+        photo: anonymous_headshot.png 
+        website: https://www.linkedin.com/in/paula-croal/?originalSubdomain=uk
+        role: Lead
+      - name: Udunna Anazodo
+        location: Lawson Health Research Institute
+        photo: anonymous_headshot.png 
+        website: https://www.lawsonresearch.ca/scientist/dr-udunna-anazodo
+        role: Co-lead
+    members:
+      - Pieter Vandemaele
+      - Jan Petr
+      - Henk-Jan Mutsaerts

--- a/_includes/taskforce/leads.md
+++ b/_includes/taskforce/leads.md
@@ -1,0 +1,21 @@
+{% for lead in include.leads %}
+<div style="display:flex">
+    <figure style="margin-bottom:1rem">
+        <img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ lead.photo }}" 
+        style="border-radius:50%; width:75px">
+    </figure>
+    <div style="padding-left:1rem; padding-top:0.5rem">
+        <p style="margin-bottom:0.1rem">
+            <b>{{ lead.role }}</b> <br/>
+        </p>
+        <p style="line-height:1rem; margin-bottom:0">
+            <a href="{{ lead.website }}" style="border-bottom:none">
+                <b>{{ lead.name }}</b> <br/>
+                <span style="font-weight: normal"> 
+                    {{ lead.location }}
+                </span>
+            </a>
+        </p>
+    </div>
+</div>
+{% endfor %}

--- a/_includes/taskforce/leads_list.html
+++ b/_includes/taskforce/leads_list.html
@@ -1,0 +1,22 @@
+<ul>
+{% for taskforces in site.data.tf %}
+{% for taskforce in taskforces %}
+{% assign taskforce_title = taskforce.title | split: ":" | first %}
+
+{% for lead in taskforce.leads %}
+<li>
+<a href="{{ lead.website }}"><b>{{ lead.name }}</b></a> ({{ taskforce_title }} {{ lead.role }})
+</li>
+{% endfor %}
+
+{% for subgroup in taskforce.subgroups %}
+{% for lead in subgroup.leads %}
+<li>
+<a href="{{ lead.website }}"><b>{{ lead.name }}</b></a> ({{ taskforce_title }} {{ lead.role }})
+</li>
+{% endfor %}
+{% endfor %}
+
+{% endfor %}
+{% endfor %}
+</ul>

--- a/_includes/taskforce/leads_list.html
+++ b/_includes/taskforce/leads_list.html
@@ -1,6 +1,7 @@
 <ul>
-{% for taskforces in site.data.tf %}
-{% for taskforce in taskforces %}
+{% assign taskforces = site.data.tf | sort %}
+{% for taskforce_array in taskforces %}
+{% assign taskforce = taskforce_array[1] %}
 {% assign taskforce_title = taskforce.title | split: ":" | first %}
 
 {% for lead in taskforce.leads %}
@@ -17,6 +18,5 @@
 {% endfor %}
 {% endfor %}
 
-{% endfor %}
 {% endfor %}
 </ul>

--- a/_includes/taskforce/members.md
+++ b/_includes/taskforce/members.md
@@ -1,0 +1,5 @@
+<ul>
+{% for member in include.members %}
+    <li> {{ member }} </li> 
+{% endfor %}
+</ul>

--- a/_includes/taskforce/subgroups.md
+++ b/_includes/taskforce/subgroups.md
@@ -1,0 +1,14 @@
+{% for subgroup in include.subgroups %}
+
+### {{ subgroup.name }}
+
+**Task force leads**
+
+{% include taskforce/leads.md leads=subgroup.leads %}
+
+**Task force members**
+
+{% include taskforce/members.md members=subgroup.members %}
+
+{% endfor %}
+

--- a/_includes/taskforce/subgroups.md
+++ b/_includes/taskforce/subgroups.md
@@ -2,10 +2,12 @@
 
 ### {{ subgroup.name }}
 
+{:.list-title}
 **Task force leads**
 
 {% include taskforce/leads.md leads=subgroup.leads %}
 
+{:.list-title}
 **Task force members**
 
 {% include taskforce/members.md members=subgroup.members %}

--- a/_includes/taskforce_content.md
+++ b/_includes/taskforce_content.md
@@ -8,47 +8,31 @@
 
 {{ taskforce.description }}
 
+<!-- SUBGROUPS -->
+{% if taskforce.subgroups %}
+---
+{% include taskforce/subgroups.md subgroups=taskforce.subgroups %}
+{% endif %}
+
+<!-- LEADS -->
 {% if taskforce.leads %}
 ---
-
 ### Task force leads
 
-{% for lead in taskforce.leads %}
-<div style="display:flex">
-    <figure style="margin-bottom:1rem">
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ lead.photo }}" 
-        style="border-radius:50%; width:75px">
-    </figure>
-    <div style="padding-left:1rem; padding-top:0.5rem">
-        <p style="margin-bottom:0.1rem">
-            <b>{{ lead.role }}</b> <br/>
-        </p>
-        <p style="line-height:1rem; margin-bottom:0">
-            <a href="{{ lead.website }}" style="border-bottom:none">
-                <b>{{ lead.name }}</b> <br/>
-                <span style="font-weight: normal"> 
-                    {{ lead.location }}
-                </span>
-            </a>
-        </p>
-    </div>
-</div>
-{% endfor %}
+{% include taskforce/leads.md leads=taskforce.leads %}
 {% endif %}
 
+<!-- MEMBERS -->
 {% if taskforce.members %}
 ---
-
 ### Task force members 
 
-<ul>
-{% for member in taskforce.members %}
-    <li> {{ member }} </li> 
-{% endfor %}
-</ul>
+{% include taskforce/members.md members=taskforce.members %}
 {% endif %}
----
 
+<!-- Status -->
+{% if taskforce.status %}
+---
 ### Task force status  
 
 <ul>
@@ -56,10 +40,11 @@
     <li> {{ status }} </li> 
 {% endfor %}
 </ul>
+{% endif %}
 
+<!-- Status -->
 {% if taskforce.resources %}
 ---
-
 ### Resources
 
 <ul>

--- a/pages/pages-root-folder/executive-management-board.md
+++ b/pages/pages-root-folder/executive-management-board.md
@@ -24,18 +24,14 @@ The EMB consists of the OSIPI leadership team and one co-lead for each task forc
 {:.list-title}
 **Current EMB members**
 
+{:style="margin-bottom:0"}
 - [**Steven Sourbron**](https://www.linkedin.com/in/steven-sourbron-93775752/?originalSubdomain=uk/) (OSIPI chair)
 - [**Laura Bell**](https://www.linkedin.com/in/lauracbell/) (OSIPI co-chair)
 - [**Henk-Jan Mutsaerts**](https://www.linkedin.com/in/henk-jan-mutsaerts-8532b626/) (OSIPI secretary)
 - [**Charlotte Debus**](https://www.linkedin.com/in/charlotte-debus-316214a0/?originalSubdomain=de) (OSIPI past-chair)
-- **Jan Petr** (OSIPI task force 1.1 co-lead)
-- **Simon Levy** (OSIPI task force 2.1 co-lead)
-- **Matthias Schabel** (OSIPI task force 2.1 co-lead)
-- **David Thomas** (OSIPI task force 4.1 co-lead)
-- [**Ina Kompan**](https://www.dkfz.de/en/mic/team/people/Ina_Kompan.html) (OSIPI task force 4.2 co-lead)
-- **David Buckley** (OSIPI task force 4.2 co-lead)
-- **Anahita Fathi** (OSIPI task force 6.1 co-lead)
-- Other task force leads to be determined.
+
+{% include taskforce/leads_list.html %}
+
 
 {:.list-title}
 **EMB meetings**

--- a/pages/pages-root-folder/task-force-6-1.md
+++ b/pages/pages-root-folder/task-force-6-1.md
@@ -1,32 +1,8 @@
 ---
-layout: page
+layout: taskforce
+tf: "tf_6_1"
 permalink: "/task-force-6-1/"
-title: "OSIPI Task Force 6.1: Challenges"
 header: no
-#subheadline: "... because we need one!"
 ---
 
-{:.list-title}
-**Task force aims**
-
-- Develop and implement challenges involving perfusion imaging analysis
-
-{:.list-title}
-**DSC challenge members**
-
-- (**Lead**)[Anahita Fathi](https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/)
-- Other members TBC
-
-{:.list-title}
-**ASL challenge members**
-
-- (**Lead**)[Paola Croal](https://www.linkedin.com/in/paula-croal/?originalSubdomain=uk)
-- (**Co-Lead**)[Udunna Anazodo](https://www.lawsonresearch.ca/scientist/dr-udunna-anazodo)
-- Pieter Vandemaele
-- Jan Petr
-- Henk-Jan Mutsaerts
-
-{:.list-title}
-**This task force is part of aim 6:**
-
-Development of benchmarks and application to existing software. Using the data collected in aim #3, develop metrics that quantify the performance of a perfusion analysis tool (eg. bias and precision on DRO’s, agreement with reference methods in-vivo, reproducibility on in-vivo data, processing time, etc). These metrics will be measured for the software tools collected in aims #1 and #2 in order to establish a set of benchmarks. The long-term aim is to establish OSIPI as an independent arbiter for software solutions in perfusion imaging. TF 6.1 will focus on the developing and implementing challenges.
+{% include taskforce_content.md %}


### PR DESCRIPTION
This PR follows up on #36 by updating the page for TF 6.1. This taskforce has two subgroups, so a `subgroups` field was added to [`_data/tf/tf_6_1.yml`](https://github.com/notZaki/osipi.github.io/blob/tf_6/_data/tf/tf_6_1.yml). 
Please double check that the location/website information for the co/leads is accurate.
[[Preview]](https://notzaki.github.io/osipi.github.io/task-force-6-1/).

Unrelated change (should've made it a different PR): 
The co/leads in the EMB members list are now updated from the YAML data files. The advantage is that the list doesn't have to be manually updated each time a new co/lead is added. A limitation is that the code assumes that each taskforce has unique co/leads (i.e. one person can not serve as co/lead on two different taskforces).
[[Preview]](https://notzaki.github.io/osipi.github.io/emb/)

