### PR TITLE
Show taskforce member's website/location

### DIFF
--- a/_includes/taskforce/members.md
+++ b/_includes/taskforce/members.md
@@ -1,5 +1,17 @@
 <ul>
 {% for member in include.members %}
-    <li> {{ member }} </li> 
+    {%- if member.name -%}
+    <li> <p style="line-height:1rem; margin-bottom:0.1rem">
+        <b> {{ member.name }} </b>
+        {%- if member.website -%}
+             <sup> <a class="icon-export"  href="{{ member.website }}" style="border-bottom:none"></a> </sup>
+        {%- endif -%} 
+        {%- if member.location -%}
+            <br/> {{ member.location }}
+        {%- endif -%}
+    </p> </li>
+    {%- else -%}
+        <li> {{ member }} </li> 
+    {%- endif -%}
 {% endfor %}
 </ul>

--- a/_taskforces/task-force-3-2.md
+++ b/_taskforces/task-force-3-2.md
@@ -14,17 +14,29 @@ leads:
     website: http://www.spl.harvard.edu/pages/People/fedorov/
     role: Lead
 members:
-  - Zaki Ahmed (https://github.com/notzaki) McGill University, Canada
-  - Beatriz Asenjo Garcia, Regional University Hospital of Málaga, Spain
-  - Greg Cron (https://med.uottawa.ca/radiology/people/cron-greg), Ottawa Hospital Research Institute, Canada
-  - Pauline Hall Barrientos
-  - Jochen Hirsch, Fraunhofer MEVIS, Germany
-  - Thomas Lindner, University Hospital Hamburg-Eppendorf, Germany
-  - Felix Navarro (https://github.com/felixnavarro) Regional University Hospital of Málaga, Spain
-  - Federico Pineda
-  - Annette van der Toorn, University Medical Center Utrecht, The Netherlands
-  - Lutz Lüdemann, Universitätsklinikum Essen, Germany
-  - Anahita Fathi, University of Pennsylvania, USA
+  - name: Zaki Ahmed 
+    website: https://github.com/notzaki
+    location: McGill University, Canada
+  - name: Beatriz Asenjo Garcia
+    location: Regional University Hospital of Málaga, Spain
+  - name: Greg Cron 
+    website: https://med.uottawa.ca/radiology/people/cron-greg
+    location: Ottawa Hospital Research Institute, Canada
+  - name: Pauline Hall Barrientos
+  - name: Jochen Hirsch
+    location: Fraunhofer MEVIS, Germany
+  - name: Thomas Lindner
+    location: University Hospital Hamburg-Eppendorf, Germany
+  - name: Felix Navarro
+    website: https://github.com/felixnavarro
+    location: Regional University Hospital of Málaga, Spain
+  - name: Federico Pineda
+  - name: Annette van der Toorn
+    location: University Medical Center Utrecht, The Netherlands
+  - name: Lutz Lüdemann
+    location: Universitätsklinikum Essen, Germany
+  - name: Anahita Fathi
+    location: University of Pennsylvania, USA
 status:
   - Feb 1, 2020 Lead confirmed
   - Identifying Co-lead..


### PR DESCRIPTION
This PR allows taskforce members to have a website and location (institution) which gets displayed in the taskforce page.

[Preview](https://notzaki.github.io/osipi.github.io/task-force-3-2/) for TF 3.2.

The metadata needs to have named fields for this to work. Otherwise, the old system will continue to work. 