### PR TITLE
Update TF 6.2 page with sub-subgroups

### DIFF
--- a/_includes/taskforce/subgroups.md
+++ b/_includes/taskforce/subgroups.md
@@ -2,15 +2,24 @@
 
 ### {{ subgroup.name }}
 
+{% if subgroup.leads %}
 {:.list-title}
-**Task force leads**
 
 {% include taskforce/leads.html leads=subgroup.leads %}
+{% endif %}
 
+{% if subgroup.members %}
 {:.list-title}
-**Task force members**
 
 {% include taskforce/members.md members=subgroup.members %}
+{% endif %}
+
+{% for subsubgroup in subgroup.subsubgroups %}
+**{{ subsubgroup.name }}**
+{:.list-title}
+{% include taskforce/members.md members=subsubgroup.members %}
+
+{% endfor %}
 
 {% endfor %}
 

--- a/_includes/taskforce_content.md
+++ b/_includes/taskforce_content.md
@@ -10,12 +10,6 @@
 
 {{ taskforce.description }}
 
-<!-- SUBGROUPS -->
-{% if taskforce.subgroups %}
----
-{% include taskforce/subgroups.md subgroups=taskforce.subgroups %}
-{% endif %}
-
 <!-- LEADS -->
 {% if taskforce.leads %}
 ---
@@ -30,6 +24,12 @@
 ### Task force members 
 
 {% include taskforce/members.md members=taskforce.members %}
+{% endif %}
+
+<!-- SUBGROUPS -->
+{% if taskforce.subgroups %}
+---
+{% include taskforce/subgroups.md subgroups=taskforce.subgroups %}
 {% endif %}
 
 <!-- Status -->

--- a/_taskforces/task-force-6-2.md
+++ b/_taskforces/task-force-6-2.md
@@ -21,16 +21,16 @@ subgroups:
     subsubgroups: 
       - name: Executive Advisers
         members: 
+          - Kaveh Daneshmand
+          - Hamidreza Saligheh Rad
+          - Anahita Fathi Kazerooni
+      - name: Executive Team
+        members: 
           - Farzad Alizadeh
           - Sogand Sadeghi
           - Hanieh Salari
           - Shirin Farsi
           - Salman Rezaei
-      - name: Executive Team
-        members: 
-          - Kaveh Daneshmand
-          - Hamidreza Saligheh Rad
-          - Anahita Fathi Kazerooni
   - name: Scientific Committee
     subsubgroups:
       - name: Scientific Advisers
@@ -44,9 +44,9 @@ subgroups:
           - Salman Rezaei
           - Xinze Zhou
           - Sam Sharifzadeh
-  - name: Radiologists
-    members: 
-      - Diego Pineda
+      - name: Radiologists
+        members: 
+          - Diego Pineda
 status:
   - 2020.07.23 Drafting outlines of the first challenges
 links:

--- a/_taskforces/task-force-6-2.md
+++ b/_taskforces/task-force-6-2.md
@@ -1,31 +1,53 @@
 ---
----
 permalink: "/task-force-6-2/"
 
 title: "OSIPI Task Force 6.2: DCE/DSC Challenges"
 aims: Develop and implement challenges involving DCE/DSC perfusion imaging analysis
 description: |
   To compare quantification pipelines for DSC/DCE-MRI in clinical cancer imaging applications. Through these challenges, the performance of DSC-/DCE-MRI perfusion analysis tools developed in-house by the participating groups or the available software packages will be tested and evaluated according to some metrics (eg. bias and precision on DROs, agreement with reference methods in-vivo, reproducibility on in-vivo data, processing time, etc). The contestants are encouraged to use the software tools listed in OSIPI in creating their pipelines. The aim of this task force is to establish a set of benchmarks for perfusion imaging in different applications. 
-  
-leads:
-  - name: Anahita Fathi Kazerooni
-    location: University of Pennsylvania, Philadelphia, PA, USA
-    website: https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/
-    role: Lead
-    email: fathikaa@pennmedicine.upenn.edu
-  - name: Hamidreza Saligheh Rad
-    location: Tehran University of Medical Sciences
-    website: https://www.linkedin.com/in/hamidreza-saligheh-rad-7127021a/
-    role: Co-lead
-    email: hamid.saligheh@gmail.com
-members:
-  Executive Committee:
-  	Executive Advisers: Kaveh Daneshmand, Hamidreza Saligheh Rad, Anahita Fathi Kazerooni
-	Executive Team: Farzad Alizadeh, Sogand Sadeghi, Hanieh Salari, Shirin Farsi, Salman Rezaei
-  Scientific Committee: 
-  	Scientific Advisers: Laura Bell, Hamidreza Saligheh Rad, Anahita Fathi Kazerooni
-	Scientific Team: Moss Zhao, Salman Rezaei, Xinze Zhou, Sam Sharifzadeh
-	Radiologists : Diego Pineda
+subgroups:
+  - name: Task force leads  
+    leads:
+      - name: Anahita Fathi Kazerooni
+        location: University of Pennsylvania, Philadelphia, PA, USA
+        website: https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/
+        role: Lead
+        email: fathikaa@pennmedicine.upenn.edu
+      - name: Hamidreza Saligheh Rad
+        location: Tehran University of Medical Sciences
+        website: https://www.linkedin.com/in/hamidreza-saligheh-rad-7127021a/
+        role: Co-lead
+        email: hamid.saligheh@gmail.com
+  - name: Executive Committee
+    subsubgroups: 
+      - name: Executive Advisers
+        members: 
+          - Farzad Alizadeh
+          - Sogand Sadeghi
+          - Hanieh Salari
+          - Shirin Farsi
+          - Salman Rezaei
+      - name: Executive Team
+        members: 
+          - Kaveh Daneshmand
+          - Hamidreza Saligheh Rad
+          - Anahita Fathi Kazerooni
+  - name: Scientific Committee
+    subsubgroups:
+      - name: Scientific Advisers
+        members: 
+          - Laura Bell
+          - Hamidreza Saligheh Rad
+          - Anahita Fathi Kazerooni
+      - name: Scientific Team
+        members: 
+          - Moss Zhao
+          - Salman Rezaei
+          - Xinze Zhou
+          - Sam Sharifzadeh
+  - name: Radiologists
+    members: 
+      - Diego Pineda
 status:
   - 2020.07.23 Drafting outlines of the first challenges
 links:

--- a/_taskforces/task-force-6-2.md
+++ b/_taskforces/task-force-6-2.md
@@ -5,19 +5,18 @@ title: "OSIPI Task Force 6.2: DCE/DSC Challenges"
 aims: Develop and implement challenges involving DCE/DSC perfusion imaging analysis
 description: |
   To compare quantification pipelines for DSC/DCE-MRI in clinical cancer imaging applications. Through these challenges, the performance of DSC-/DCE-MRI perfusion analysis tools developed in-house by the participating groups or the available software packages will be tested and evaluated according to some metrics (eg. bias and precision on DROs, agreement with reference methods in-vivo, reproducibility on in-vivo data, processing time, etc). The contestants are encouraged to use the software tools listed in OSIPI in creating their pipelines. The aim of this task force is to establish a set of benchmarks for perfusion imaging in different applications. 
+leads:
+  - name: Anahita Fathi Kazerooni
+    location: University of Pennsylvania, Philadelphia, PA, USA
+    website: https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/
+    role: Lead
+    email: fathikaa@pennmedicine.upenn.edu
+  - name: Hamidreza Saligheh Rad
+    location: Tehran University of Medical Sciences
+    website: https://www.linkedin.com/in/hamidreza-saligheh-rad-7127021a/
+    role: Co-lead
+    email: hamid.saligheh@gmail.com
 subgroups:
-  - name: Task force leads  
-    leads:
-      - name: Anahita Fathi Kazerooni
-        location: University of Pennsylvania, Philadelphia, PA, USA
-        website: https://www.linkedin.com/in/anahita-fathi-kazerooni-a3287238/
-        role: Lead
-        email: fathikaa@pennmedicine.upenn.edu
-      - name: Hamidreza Saligheh Rad
-        location: Tehran University of Medical Sciences
-        website: https://www.linkedin.com/in/hamidreza-saligheh-rad-7127021a/
-        role: Co-lead
-        email: hamid.saligheh@gmail.com
   - name: Executive Committee
     subsubgroups: 
       - name: Executive Advisers


### PR DESCRIPTION
The [TF 6.2 page](https://www.osipi.org/task-force-6-2/) was not displaying correctly. 
It looks like the taskforce has multiple committees and this is not accommodated by the current system. 

This PR modifies the subgroup feature which was introduced in #40 but is not being currently used by any page.
The modification adds a second layer of subgroups, i.e. subsubgroups, which can be used to organized the committees in TF 6.2.
[Preview of new TF 6.2 page](https://notzaki.github.io/osipi.github.io/task-force-6-2/)

@anahitafk Let me know if this is what the page was intended to look like, and if I made any mistakes while re-organizing the committee/member list