### PR TITLE
Preserve order of navigation menu in mobile version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .DS_Store
+.jekyll-cache/

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -14,6 +14,62 @@
       <li class="toggle-topbar menu-icon"><a href="#"><span>Nav</span></a></li>
     </ul>
     <section class="top-bar-section">
+  {% comment %}
+
+      __         ______     _   __            _             __  _
+     / /   ___  / __/ /_   / | / /___ __   __(_)___ _____ _/ /_(_)___  ____
+    / /   / _ \/ /_/ __/  /  |/ / __ `/ | / / / __ `/ __ `/ __/ / __ \/ __ \
+   / /___/  __/ __/ /_   / /|  / /_/ /| |/ / / /_/ / /_/ / /_/ / /_/ / / / /
+  /_____/\___/_/  \__/  /_/ |_/\__,_/ |___/_/\__, /\__,_/\__/_/\____/_/ /_/
+                                            /____/
+  
+  {% endcomment %}
+        <ul class="left">
+          {% for link in site.data.navigation %}
+  
+                {% if link.url contains 'http' %}
+                  {% assign domain = '' %}
+                {% elsif link.url == '#' %}
+                  {% assign domain = '' %}
+                {% else %}
+                  {% assign domain = site.url %}
+                {% endif %}
+  
+            {% comment %}   If there are links for left side begin   {% endcomment %}
+            {% if link.side == 'left' %}
+  
+              {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
+              {% if link.dropdown == nil %}
+                <li{% if link.url == page.url %} class="active"{% elsif page.homepage == true and link.url == '/' %} class="active"{% endif %}><a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a></li>
+                <li class="divider"></li>
+  
+              {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
+              {% else %}
+  
+                <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
+                  <a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a>
+  
+                    <ul class="dropdown">
+                      {% for dropdown_link in link.dropdown %}
+  
+                        {% if dropdown_link.url contains 'http' %}
+                          {% assign domain = '' %}
+                          {% else %}
+                          {% assign domain = site.url %}
+                        {% endif %}
+  
+                        <li><a {% if dropdown_link.class %}class="{{dropdown_link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title | escape }}</a></li>
+                      {% endfor %}
+                    </ul>
+  
+                </li>
+                <li class="divider"></li>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+          {% comment %}   Second loop finished   {% endcomment %}
+        </ul>
+
 {% comment %}
 
     ____  _       __    __     _   __            _             __  _
@@ -68,61 +124,7 @@
         {% endfor %}
         {% comment %}   First loop finished 1   {% endcomment %}
       </ul>
-{% comment %}
 
-    __         ______     _   __            _             __  _
-   / /   ___  / __/ /_   / | / /___ __   __(_)___ _____ _/ /_(_)___  ____
-  / /   / _ \/ /_/ __/  /  |/ / __ `/ | / / / __ `/ __ `/ __/ / __ \/ __ \
- / /___/  __/ __/ /_   / /|  / /_/ /| |/ / / /_/ / /_/ / /_/ / /_/ / / / /
-/_____/\___/_/  \__/  /_/ |_/\__,_/ |___/_/\__, /\__,_/\__/_/\____/_/ /_/
-                                          /____/
-
-{% endcomment %}
-      <ul class="left">
-        {% for link in site.data.navigation %}
-
-              {% if link.url contains 'http' %}
-                {% assign domain = '' %}
-              {% elsif link.url == '#' %}
-                {% assign domain = '' %}
-              {% else %}
-                {% assign domain = site.url %}
-              {% endif %}
-
-          {% comment %}   If there are links for left side begin   {% endcomment %}
-          {% if link.side == 'left' %}
-
-            {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
-            {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% elsif page.homepage == true and link.url == '/' %} class="active"{% endif %}><a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a></li>
-              <li class="divider"></li>
-
-            {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
-            {% else %}
-
-              <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a {% if link.class %}class="{{link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title | escape }}</a>
-
-                  <ul class="dropdown">
-                    {% for dropdown_link in link.dropdown %}
-
-                      {% if dropdown_link.url contains 'http' %}
-                        {% assign domain = '' %}
-                        {% else %}
-                        {% assign domain = site.url %}
-                      {% endif %}
-
-                      <li><a {% if dropdown_link.class %}class="{{dropdown_link.class}}"{% endif %} href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title | escape }}</a></li>
-                    {% endfor %}
-                  </ul>
-
-              </li>
-              <li class="divider"></li>
-            {% endif %}
-          {% endif %}
-        {% endfor %}
-        {% comment %}   Second loop finished   {% endcomment %}
-      </ul>
     </section>
   </nav>
 </div><!-- /#navigation -->


### PR DESCRIPTION
The top-menu on the desktop version has links on the left and right side. 
The mobile version groups these links together, however, the links from the right-side appear before the ones from the left-side. It would be more intuitive if links from the left-side were listed first.

This PR changes the order of links and they now maintain the left-to-right order on mobile versions. [Preview](https://notzaki.github.io/osipi.github.io/)