### PR TITLE
TF6.2 - Add 'name' field in member list

### DIFF
--- a/_taskforces/task-force-6-2.md
+++ b/_taskforces/task-force-6-2.md
@@ -17,15 +17,15 @@ leads:
     role: Co-lead
     email: hamid.saligheh@gmail.com
 members:
-  - Laura Bell
+  - name: Laura Bell
     website: https://www.linkedin.com/in/lauracbell/
     location: Barrow Neurological Institute
   - Xinze Zhou
-  - Rianne van der Heijden
+  - name: Rianne van der Heijden
     website: https://www.linkedin.com/in/riannevanderheijden1/
     location: Erasmus Universiteit Rotterdam
   - Moss Zhao
-  - Zaki Ahmed
+  - name: Zaki Ahmed
     website: https://github.com/notzaki
     location: McGill University, Canada
   - Diego Pineda


### PR DESCRIPTION
The [TF 6.2 page](https://www.osipi.org/task-force-6-2/) was not loading for me. This PR tries to fix that.

I think the issue was that some entries in the member list contain multiple fields, e.g. `website` & `location`, but they did not specify a `name` field. Adding this field should resolve the issue.