### PR TITLE
Show member email if it exists

### DIFF
--- a/_includes/taskforce/members.md
+++ b/_includes/taskforce/members.md
@@ -9,6 +9,9 @@
         {%- if member.location -%}
             <br/> {{ member.location }}
         {%- endif -%}
+        {%- if member.email -%}
+            <br/> <a href="mailto:{{ member.email }}">{{ member.email }}</a> <br/>
+        {%- endif -%}
     </p> </li>
     {%- else -%}
         <li> {{ member }} </li> 


### PR DESCRIPTION
An `email:` field can now be specified in the taskforce members list and it will be displayed on the webpage.