### PR TITLE
Remove personal webpage icon for member list

### DIFF
--- a/_includes/taskforce/members.md
+++ b/_includes/taskforce/members.md
@@ -1,10 +1,13 @@
 <ul>
 {% for member in include.members %}
     {%- if member.name -%}
-    <li> <p style="line-height:1rem; margin-bottom:0.1rem">
+    <li> <p style="line-height:1rem; margin-bottom:0.3rem">
+        {%- if member.website -%}
+            <a href="{{ member.website }}" style="border-bottom:none">
+        {%- endif -%} 
         <b> {{ member.name }} </b>
         {%- if member.website -%}
-             <sup> <a class="icon-export"  href="{{ member.website }}" style="border-bottom:none"></a> </sup>
+            </a>
         {%- endif -%} 
         {%- if member.location -%}
             <br/> {{ member.location }}


### PR DESCRIPTION
The member list uses an icon that links to each member's personal page. This PR removes the icon and uses the member name as the hyperlink. This makes it consistent with the co-lead section, as their name also acts as a hyperlink to their website, and it avoids issues with the icon overlapping with the line above it #103 
