### PR TITLE
Fix tooltip text for X social icon

### DIFF
--- a/docs/javascripts/fix-xitter-tooltip.js
+++ b/docs/javascripts/fix-xitter-tooltip.js
@@ -1,0 +1,47 @@
+// Fix the tooltip text for the X / (formerly Twitter) social icon.
+// Some icon packs label the icon as "Xitter"; we normalize it to "X".
+//
+// For MkDocs Material, run on initial load and on page navigation events.
+(function () {
+  function applyFix(root) {
+    var scope = root && root.querySelectorAll ? root : document;
+
+    // Fix tooltips on links/elements.
+    var els = scope.querySelectorAll(
+      '[title="Xitter"], [aria-label="Xitter"], [data-md-tooltip="Xitter"]'
+    );
+    for (var i = 0; i < els.length; i++) {
+      if (els[i].getAttribute('title') === 'Xitter') els[i].setAttribute('title', 'X');
+      if (els[i].getAttribute('aria-label') === 'Xitter') els[i].setAttribute('aria-label', 'X');
+      if (els[i].getAttribute('data-md-tooltip') === 'Xitter') els[i].setAttribute('data-md-tooltip', 'X');
+    }
+
+    // Fix tooltips embedded inside SVGs.
+    var titles = scope.querySelectorAll('svg title');
+    for (var j = 0; j < titles.length; j++) {
+      if ((titles[j].textContent || '').trim() === 'Xitter') {
+        titles[j].textContent = 'X';
+      }
+    }
+  }
+
+  // Initial load.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      applyFix(document);
+    });
+  } else {
+    applyFix(document);
+  }
+
+  // MkDocs Material: run on every page change if the theme provides document$.
+  try {
+    if (window.document$ && typeof window.document$.subscribe === 'function') {
+      window.document$.subscribe(function () {
+        applyFix(document);
+      });
+    }
+  } catch (e) {
+    // best-effort only
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ extra_css:
   - assets/stylesheets/extra.css
 extra_javascript:
   - js/mathjax-config.js
+  - javascripts/fix-xitter-tooltip.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 # Extensions


### PR DESCRIPTION
Fixes #166.

Adds a small JS helper that normalizes the X/Twitter icon tooltip label from "Xitter" to "X" (covers title/aria-label and SVG <title>). The script runs on initial load and on Material for MkDocs page navigation (document$).
